### PR TITLE
bugfix: fix broken scrollycoding

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -15,7 +15,6 @@
 
 :root {
   --ch-scrollycoding-sticker-width: 650px;
-  --ch-scrollycoding-code-min-height: min-content;
 }
 
 .ch-expand-dialog {


### PR DESCRIPTION
Nearly all scrollycoding examples overlapped other text, so the content wasn't readable.